### PR TITLE
Removed unwanted package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 configparser
 certifi
-warnings


### PR DESCRIPTION
```warnings``` is builtin. No need to install it.